### PR TITLE
Stage DDST alyssa

### DIFF
--- a/ETSMobile.xcodeproj/project.pbxproj
+++ b/ETSMobile.xcodeproj/project.pbxproj
@@ -113,9 +113,9 @@
 		9C5799D118EC7F2D00AD8838 /* ETSSecurityDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C5799D018EC7F2D00AD8838 /* ETSSecurityDetailViewController.m */; };
 		9CC88724189ECF43002A3D04 /* ETSSecurityViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CC88723189ECF43002A3D04 /* ETSSecurityViewController.m */; };
 		9CC88727189ED56B002A3D04 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CC88726189ED56B002A3D04 /* MapKit.framework */; };
-		C1E8B04E276C9543B0B92EF4 /* libPods-ETSMobile.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DE67BBDCCED00037D3BB48E /* libPods-ETSMobile.a */; };
 		D15F4AE4183992D00034605B /* ETSProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D15F4AE3183992D00034605B /* ETSProfileViewController.m */; };
 		D15F4AE71839A80B0034605B /* ETSProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = D15F4AE61839A80B0034605B /* ETSProfile.m */; };
+		D7E5B876F1B85E3746567E44 /* Pods_ETSMobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21C3A12838884264666B3170 /* Pods_ETSMobile.framework */; };
 		E90350EE1B987A670093C8E1 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 269B46D81A1123300052E4B7 /* CoreTelephony.framework */; };
 		E90350F01B987A670093C8E1 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E90350EF1B987A670093C8E1 /* CoreText.framework */; };
 		E90350F21B987A7C0093C8E1 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E90350F11B987A7C0093C8E1 /* libxml2.dylib */; };
@@ -153,6 +153,7 @@
 		1D8B140D19A7B1E80033CBA7 /* GTMNSString+HTML.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "GTMNSString+HTML.m"; path = "Vendors/GTMNSString+HTML/GTMNSString+HTML.m"; sourceTree = "<group>"; };
 		1DBF6C6719A507EA00761C44 /* ETSNewsSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ETSNewsSource.h; sourceTree = "<group>"; };
 		1DBF6C6819A507EA00761C44 /* ETSNewsSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ETSNewsSource.m; sourceTree = "<group>"; };
+		21C3A12838884264666B3170 /* Pods_ETSMobile.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ETSMobile.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2600DB06190767000039039A /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		2601088D181596820037E795 /* ETSCollectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ETSCollectionViewController.h; sourceTree = "<group>"; };
 		26085B3C1829D84300FE35AB /* ETSAPIURL.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ETSAPIURL.plist; sourceTree = "<group>"; };
@@ -327,7 +328,6 @@
 		2942BEFF1BF3B43C0032C79A /* ETSAboutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ETSAboutViewController.swift; sourceTree = "<group>"; };
 		296B68411BD52C11003A8E62 /* Launch_Screen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = Launch_Screen.xib; sourceTree = "<group>"; };
 		29CFAC4C1BBD09590027CC2E /* ETS-logo-blanc.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "ETS-logo-blanc.png"; path = "Images.xcassets/ETS-logo-blanc.imageset/ETS-logo-blanc.png"; sourceTree = "<group>"; };
-		2DE67BBDCCED00037D3BB48E /* libPods-ETSMobile.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ETSMobile.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C5799CF18EC7F2D00AD8838 /* ETSSecurityDetailViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ETSSecurityDetailViewController.h; sourceTree = "<group>"; };
 		9C5799D018EC7F2D00AD8838 /* ETSSecurityDetailViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ETSSecurityDetailViewController.m; sourceTree = "<group>"; };
 		9CC88722189ECF43002A3D04 /* ETSSecurityViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ETSSecurityViewController.h; sourceTree = "<group>"; };
@@ -369,7 +369,7 @@
 				26AE185D17F296CD00DB1EB4 /* QuartzCore.framework in Frameworks */,
 				26DD92AE17EA610D00469FA8 /* CoreData.framework in Frameworks */,
 				26DD92A817EA610D00469FA8 /* Foundation.framework in Frameworks */,
-				C1E8B04E276C9543B0B92EF4 /* libPods-ETSMobile.a in Frameworks */,
+				D7E5B876F1B85E3746567E44 /* Pods_ETSMobile.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -691,7 +691,7 @@
 				26DD92AB17EA610D00469FA8 /* UIKit.framework */,
 				26DD92AD17EA610D00469FA8 /* CoreData.framework */,
 				26DD92D117EA610D00469FA8 /* XCTest.framework */,
-				2DE67BBDCCED00037D3BB48E /* libPods-ETSMobile.a */,
+				21C3A12838884264666B3170 /* Pods_ETSMobile.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Podfile
+++ b/Podfile
@@ -1,9 +1,9 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '8.0'
+platform :ios, '7.0'
 use_frameworks!
 
 target 'ETSMobile' do
-    pod 'AMScrollingNavbar’, '1.5'
+    pod 'AMScrollingNavbar'
     pod 'Fabric'
     pod 'Crashlytics'
     pod 'MSDynamicsDrawerViewController'

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,9 @@
 # Uncomment this line to define a global platform for your project
 platform :ios, '8.0'
+use_frameworks!
 
 target 'ETSMobile' do
-    pod 'AMScrollingNavbar'
+    pod 'AMScrollingNavbar’, '1.5'
     pod 'Fabric'
     pod 'Crashlytics'
     pod 'MSDynamicsDrawerViewController'
@@ -11,6 +12,7 @@ target 'ETSMobile' do
     pod 'SupportKit', '2.11.0'
     pod 'DZNEmptyDataSet'
    	pod 'RKDropdownAlert'
+
 end
 
 target 'ETSMobileTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,7 +15,7 @@ PODS:
   - SupportKit (2.11.0)
 
 DEPENDENCIES:
-  - AMScrollingNavbar (= 1.5)
+  - AMScrollingNavbar
   - Crashlytics
   - DZNEmptyDataSet
   - Fabric

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,22 +1,21 @@
 PODS:
-  - AMScrollingNavbar (1.5.1)
-  - Crashlytics (3.3.4)
+  - AMScrollingNavbar (1.5)
+  - Crashlytics (3.7.0):
+    - Fabric (~> 1.6.3)
   - CupertinoYankee (0.1.1)
-  - DZNEmptyDataSet (1.7.2)
-  - Fabric (1.5.1):
-    - Fabric/Base (= 1.5.1)
-  - Fabric/Base (1.5.1)
+  - DZNEmptyDataSet (1.8)
+  - Fabric (1.6.7)
   - MSCollectionViewCalendarLayout (0.1.3):
     - CupertinoYankee (~> 0.1)
   - MSDynamicsDrawerViewController (1.5.1)
   - RKDropdownAlert (0.3.0)
-  - SDWebImage (3.7.3):
-    - SDWebImage/Core (= 3.7.3)
-  - SDWebImage/Core (3.7.3)
+  - SDWebImage (3.7.5):
+    - SDWebImage/Core (= 3.7.5)
+  - SDWebImage/Core (3.7.5)
   - SupportKit (2.11.0)
 
 DEPENDENCIES:
-  - AMScrollingNavbar
+  - AMScrollingNavbar (= 1.5)
   - Crashlytics
   - DZNEmptyDataSet
   - Fabric
@@ -27,15 +26,15 @@ DEPENDENCIES:
   - SupportKit (= 2.11.0)
 
 SPEC CHECKSUMS:
-  AMScrollingNavbar: 767ed2db60d927a809bddff5d01b739b7020b12b
-  Crashlytics: 41c082440d2e14da444186fff65e79c0b4b35d4c
+  AMScrollingNavbar: 43f44058eccb38083db2f20b722c51d5796df7da
+  Crashlytics: c3a2333dea9e2733d2777f730910321fc9e25c0d
   CupertinoYankee: 742ab22e47518167d0c78d2eaa5aed5b6e26af3b
-  DZNEmptyDataSet: 0ec00bfc230d7450997b60c127afdd0b9f24f3b6
-  Fabric: 03c3b3fe77e11a2bc31421b989a9c7adaa4779a5
+  DZNEmptyDataSet: d2351b2e8daefa40433ef292e246e21f6be31a7b
+  Fabric: caf7580c725e64db144f610ac65cd60956911dc7
   MSCollectionViewCalendarLayout: fba6fefdb3a340cb3e4f10725c6b3a530e6f6817
   MSDynamicsDrawerViewController: 2874df90f5e9453dc7d4e32f8038b50615d4baa7
   RKDropdownAlert: f4b3364c251829ad439dc666836a1f2dad26f4c7
-  SDWebImage: 1d2b1a1efda1ade1b00b6f8498865f8ddedc8a84
+  SDWebImage: 69c6303e3348fba97e03f65d65d4fbc26740f461
   SupportKit: 07e72f5e93c1055adcc810dd715aefc34e0ab279
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
In order to support iOS 7.0 we have to update libraries only until the
last version that supports it. Before it could cause problems as we had
to do this manually, however cocoa pods can do this automatically if we
specify the correct target platform.